### PR TITLE
Fix: Responsive screen on mobile and tablet screen sizes

### DIFF
--- a/_includes/jumbotron_front.html
+++ b/_includes/jumbotron_front.html
@@ -14,7 +14,7 @@
         </div>
      </div>
     <div class="row justify-content-center">
-        <div class="col-sm-9">
+        <div class="col-12 col-lg-6">
 
 <div class="card-deck front" style="color: #444;">
   <div class="card">

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -999,7 +999,6 @@ iframe {
 
 #team .rounded-circle {
     max-width: 120px !important;
-    margin-bottom: -6em;
 }
 
 #team .card {


### PR DESCRIPTION
Before:
![Screenshot 2022-10-25 at 22 45 20](https://user-images.githubusercontent.com/63148200/197982161-df740e97-5bed-4689-9fd8-04d7e89fc97f.png)
After:
![Screenshot 2022-10-25 at 22 46 45](https://user-images.githubusercontent.com/63148200/197982242-0270fca6-8977-4e33-bc68-7b89eabc6a91.png)

Before:
<img width="434" alt="Screenshot 2022-10-25 at 23 49 35" src="https://user-images.githubusercontent.com/63148200/197982365-4fe466c6-c3e3-402b-8a18-0e8821b69138.png">
After:
<img width="427" alt="Screenshot 2022-10-26 at 09 59 18" src="https://user-images.githubusercontent.com/63148200/197982783-a9160bde-b3b4-48a3-82e3-a781c31575e1.png">
